### PR TITLE
Fix parsing nested sections

### DIFF
--- a/modules/core/src/main/scala/yamusca/parser/mustache.scala
+++ b/modules/core/src/main/scala/yamusca/parser/mustache.scala
@@ -100,7 +100,7 @@ object mustache extends Parsers {
   def consumeUntilEndSection(name: String): Parser[ParseInput] = { in =>
     val delim = in.delim.start + "/"
     val stop: ParseInput => Boolean = in => {
-      (ignoreWs ~ consume(name))(in).isRight
+      (ignoreWs ~ consume(name) ~ ignoreWs ~ consume(in.delim.end))(in).isRight
     }
     @annotation.tailrec
     def go(pin: ParseInput): Option[(ParseInput, ParseInput)] =

--- a/modules/core/src/test/scala/yamusca/YamuscaSpec.scala
+++ b/modules/core/src/test/scala/yamusca/YamuscaSpec.scala
@@ -29,6 +29,24 @@ class YamuscaSpec extends FlatSpec with Matchers {
     t.renderResult(Context.empty) should be ("Hello world!")
   }
 
+  it should "render nested same sections" in {
+    expectResult(
+      "{{#a.b}}Hello {{#d.e}}world{{/d.e}}{{/a.b}}",
+      "Hello world",
+      Context("a" -> Value.map("b" -> Value.fromBoolean(true)), "d" -> Value.map("e" -> Value.fromBoolean(true)))
+    )
+    expectResult(
+      "{{#a.b}}Hello {{#c}}world{{/c}}{{/a.b}}",
+      "Hello world",
+      Context("a" -> Value.map("b" -> Value.map("c" -> Value.fromBoolean(true))))
+    )
+    expectResult(
+      "{{#a.b}}Hello {{#a.b.c}}world{{/a.b.c}}{{/a.b}}",
+      "Hello world",
+      Context("a" -> Value.map("b" -> Value.map("c" -> Value.fromBoolean(true))))
+    )
+  }
+
   it should "replace variables" in {
     val t = Template(Literal("Hello "), Variable("name"), Literal("!"))
     val context = Context("name" -> Value.of("Harry"))


### PR DESCRIPTION
If a nested section with same prefix as outer was parsed, the end
section was not correctly determined.

Fixes #7